### PR TITLE
Delete vault-infra repo

### DIFF
--- a/data/browningluke-iac.yml
+++ b/data/browningluke-iac.yml
@@ -78,20 +78,6 @@
   init: true
   gitignore: Terraform
 
-- name: vault-infra
-  description: ""
-  public: true
-  template:
-    owner: browningluke-tf
-    repo: tf-template
-  has:
-    downloads: false
-    issues: false
-    projects: false
-    wiki: false
-  init: true
-  gitignore: Terraform
-
 # ==== PVE repos ====
 - name: pve-hosts
   description: ""


### PR DESCRIPTION
`sol-vault` hosted on `sol-k8s` cluster now. Therefore there is no infra specifically for vault.